### PR TITLE
[fix]: getPriceImpact

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@meteora-ag/cp-amm-sdk",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"description": "SDK for Cp Amm",
 	"main": "./dist/index.js",
 	"module": "./dist/index.mjs",
@@ -14,6 +14,7 @@
 		"lint:fix": "prettier */*.js \"*/**/*{.js,.ts}\" -w",
 		"lint": "prettier */*.js \"*/**/*{.js,.ts}\" --check",
 		"build": "tsup",
+		"clean": "rm -rf dist && rm -rf node_modules",
 		"start": "npm run build -- --watch",
 		"test": "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/*.test.ts"
 	},

--- a/src/CpAmm.ts
+++ b/src/CpAmm.ts
@@ -1046,7 +1046,14 @@ export class CpAmm {
       swapOutAmount: actualAmountOut,
       minSwapOutAmount,
       totalFee,
-      priceImpact: getPriceImpact(nextSqrtPrice, sqrtPriceQ64),
+      priceImpact: getPriceImpact(
+        actualAmountIn,
+        actualAmountOut,
+        sqrtPriceQ64,
+        aToB,
+        params.tokenADecimal,
+        params.tokenBDecimal
+      ),
     };
   }
 
@@ -1118,7 +1125,14 @@ export class CpAmm {
       Math.ceil(actualInputAmount.toNumber() * (1 + slippage / 100))
     );
 
-    const priceImpact = getPriceImpact(swapResult.nextSqrtPrice, sqrtPriceQ64);
+    const priceImpact = getPriceImpact(
+      actualInputAmount,
+      actualAmountOut,
+      sqrtPriceQ64,
+      !bToA, // aToB is the opposite of bToA
+      params.tokenADecimal,
+      params.tokenBDecimal
+    );
 
     return {
       swapResult,

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -37,7 +37,7 @@ export const getMinAmountWithSlippage = (amount: BN, rate: number) => {
  * @param aToB - Direction of swap: true for token A to token B, false for token B to token A
  * @param tokenADecimal - Decimal places for token A
  * @param tokenBDecimal - Decimal places for token B
- * @returns Price impact as a percentage (e.g., 1.5 means 1.5% worse than spot price)
+ * @returns Price impact as a percentage
  */
 export const getPriceImpact = (
   amountIn: BN,
@@ -80,7 +80,7 @@ export const getPriceImpact = (
  * This measures the percentage change in pool price after a swap
  * @param nextSqrtPrice sqrt price after swap
  * @param currentSqrtPrice current pool sqrt price
- * @returns Price change as a percentage (e.g., 1.5 means 1.5% change)
+ * @returns Price change as a percentage
  */
 export const getPriceChange = (
   nextSqrtPrice: BN,

--- a/src/types.ts
+++ b/src/types.ts
@@ -369,6 +369,8 @@ export type GetQuoteParams = {
     mint: Mint;
     currentEpoch: number;
   };
+  tokenADecimal: number;
+  tokenBDecimal: number;
 };
 
 export type SwapAmount = {
@@ -391,6 +393,8 @@ export type GetQuoteExactOutParams = {
     mint: Mint;
     currentEpoch: number;
   };
+  tokenADecimal: number;
+  tokenBDecimal: number;
 };
 
 export type SwapResult = {


### PR DESCRIPTION
### Context

Previous function calculated price change from `currentSqrtPrice` and `nextSqrtPrice`

Price Impact should be averaged execution price difference from the spot price

Shifted the old price change function to `getPriceChange`